### PR TITLE
Markdown support added to php-quill-renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A curated list of awesome things related to Quill
 
 ### Deltas
 
-- [php-quill-renderer](https://github.com/deanblackborough/php-quill-renderer) - Render quill insert deltas to HTML
+- [php-quill-renderer](https://github.com/deanblackborough/php-quill-renderer) - Render quill insert deltas to HTML and Markdown
 - [quill-delta-to-html](https://github.com/nozer/quill-delta-to-html) - Converts Quill's delta ops to HTML
 - [go-render-quill](https://github.com/dchenk/go-render-quill) - A Go package to render Quill deltas into HTML
 - [quill-render](https://github.com/casetext/quill-render) - Renders quilljs deltas into HTML


### PR DESCRIPTION
* Updated description for [php-quill-renderer](https://github.com/deanblackborough/php-quill-renderer), Markdown is now a supported output format.