### PR TITLE
Updated UmbraEngineering quilljs-renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A curated list of awesome things related to Quill
 - [quill-delta-to-html](https://github.com/nozer/quill-delta-to-html) - Converts Quill's delta ops to HTML
 - [go-render-quill](https://github.com/dchenk/go-render-quill) - A Go package to render Quill deltas into HTML
 - [quill-render](https://github.com/casetext/quill-render) - Renders quilljs deltas into HTML
-- [quilljs-renderer](https://github.com/UmbraEngineering/quilljs-renderer) - Renders an insert-only Quilljs delta into various format like HTML and Markdown
+- [quilljs-renderer](https://github.com/UmbraEngineering/quilljs-renderer) - Renders an insert-only Quilljs delta into various format like HTML (FYI: project has no license)
 
 
 ### Other


### PR DESCRIPTION
The Delta resource for https://github.com/UmbraEngineering/quilljs-renderer mentioned markdown. While the README for that project mentions markdown, it actually does not support markdown at this time. It only does HTML. Further, it has no license file, which means that many (most?) projects cannot benefit from the HTML conversion it does offer.