### PR TITLE
Added in link to boomanaiden154/quillGetHTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A curated list of awesome things related to Quill
 - [go-render-quill](https://github.com/dchenk/go-render-quill) - A Go package to render Quill deltas into HTML
 - [quill-render](https://github.com/casetext/quill-render) - Renders quilljs deltas into HTML
 - [quilljs-renderer](https://github.com/UmbraEngineering/quilljs-renderer) - Renders an insert-only Quilljs delta into various format like HTML (FYI: project has no license)
+- [quillGetHTML](https://github.com/boomanaiden154/quillgethtml) - Adds a function to the quill editor `getHTML()` that provides HTML for rendering outside of Quill
 
 
 ### Other


### PR DESCRIPTION
I added in a link to one of my projects that adds a function `getHTML()` to the quill editor which returns a string of HTML. It is different from many of the other solutions that convert quill's delta object into HTML because it does not use Quill to render the content and then return the value of `rootNode.innerHTML`. It also has support for formulas. I put it at the end of the list because the name is not hyphenated, but if that needs to be changed, I can do that.