### PR TITLE
quilljs-renderer license note

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A curated list of awesome things related to Quill
 - [quill-delta-to-html](https://github.com/nozer/quill-delta-to-html) - Converts Quill's delta ops to HTML
 - [go-render-quill](https://github.com/dchenk/go-render-quill) - A Go package to render Quill deltas into HTML
 - [quill-render](https://github.com/casetext/quill-render) - Renders quilljs deltas into HTML
-- [quilljs-renderer](https://github.com/UmbraEngineering/quilljs-renderer) - Renders an insert-only Quilljs delta into various format like HTML (FYI: project has no license)
+- [quilljs-renderer](https://github.com/UmbraEngineering/quilljs-renderer) - Renders an insert-only Quilljs delta into various format like HTML
 
 
 ### Other


### PR DESCRIPTION
`quilljs-renderer` record has a note that it doesn't have a license. However `package.json` file of this project mentions that the license is ISC so I think it's safe to assume that this license is applicable and we should remove this notice to avoid confusion.