### PR TITLE
Add quill-mathlive-blot

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A curated list of awesome things related to Quill
 - [quill-magic-url](https://github.com/visualjerk/quill-magic-url) - Checks for URLs during typing / pasting and automatically converts them to links
 - [quill-markdown-shortcuts](https://github.com/patleeman/quill-markdown-shortcuts) - Quill.js module that converts markdown to rich text formatting while typing
 - [quill-markdown-toolbar](https://github.com/park53kr/quill-markdown-toolbar) - A Quill.js module for converting markdown text to rich text format
-- [quill-mathlive-blot](https://github.com/JonathanTreffler/Quill-mathLive-blot) - A Quill.js blot to embed editable formulas with mathLive
+- [quill-mathlive-blot](https://github.com/JonathanTreffler/Quill-mathLive-blot) - A Quill.js blot to insert editable formulas with mathLive
 - [quill-mention](https://github.com/afconsult/quill-mention) - @mentions for the Quill rich text editor
 - [quill-paste-smart](https://github.com/Artem-Schander/quill-paste-smart) - Paste only supported HTML
 - [quill-placeholder-module](https://github.com/jspaine/quill-placeholder-module) - A quill module for adding placeholders

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A curated list of awesome things related to Quill
 - [quill-magic-url](https://github.com/visualjerk/quill-magic-url) - Checks for URLs during typing / pasting and automatically converts them to links
 - [quill-markdown-shortcuts](https://github.com/patleeman/quill-markdown-shortcuts) - Quill.js module that converts markdown to rich text formatting while typing
 - [quill-markdown-toolbar](https://github.com/park53kr/quill-markdown-toolbar) - A Quill.js module for converting markdown text to rich text format
+- [quill-mathlive-blot](https://github.com/JonathanTreffler/Quill-mathLive-blot) - A Quill.js blot to embed editable formulas with mathLive
 - [quill-mention](https://github.com/afconsult/quill-mention) - @mentions for the Quill rich text editor
 - [quill-paste-smart](https://github.com/Artem-Schander/quill-paste-smart) - Paste only supported HTML
 - [quill-placeholder-module](https://github.com/jspaine/quill-placeholder-module) - A quill module for adding placeholders


### PR DESCRIPTION
I made a Blot/Module for Quill, that allows the user to insert a Formula, that can be edited inline, based on [mathLive](https://mathlive.io/).
It has support for pretty much everything in LATEX.

There is a [Demo](https://jonathan-treffler.de/Quill-mathLive-blot/) available.

(to avoid confusion: I also created a Pull Request for quill-mathquill-blot. It is for the same usecase, but it's not the same)